### PR TITLE
Removed 144 from EU

### DIFF
--- a/index.html
+++ b/index.html
@@ -1495,7 +1495,7 @@
                         channel: 144,
                         frequency: 5720,
                         width: 20,
-                        domain: ["WW", "US", "EU", "AU"],
+                        domain: ["WW", "US", "AU"],
                     },
                     {
                         channel: 149,


### PR DESCRIPTION
Removed the EU tag from Wi-Fi channel 144, so it will be filtered out if only EU is selected.